### PR TITLE
Add interval delay config variables

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,9 +4,10 @@
 # [interval] - Status polling interval for monit. Optional. Default 30 sec.
 #
 class monit::config (
-  $use_syslog = false,
-  $interval = 120,
-  $httpd    = false,
+  $use_syslog     = false,
+  $interval       = 120,
+  $interval_delay = undef,
+  $httpd          = false,
 ) {
 
 include monit::params

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,8 @@
 #
 class monit(
-  $interval = 120,
-  $httpd    = false,
+  $interval       = 120,
+  $interval_delay = undef,
+  $httpd          = false,
 ) {
 
   class {'monit::package':
@@ -9,10 +10,11 @@ class monit(
   }
 
   class {'monit::config':
-    interval => $interval,
-    httpd    => $httpd,
-    notify   => Class['monit::service'],
-    require  => Class['monit::package'],
+    interval       => $interval,
+    interval_delay => $interval_delay,
+    httpd          => $httpd,
+    notify         => Class['monit::service'],
+    require        => Class['monit::package'],
   }
 
   class {'monit::service':

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -17,8 +17,12 @@
 ## Start Monit in the background (run as a daemon):
 #
   set daemon <%= @interval %>             # check services at 30-sec intervals
+<%- if @interval_delay %>
+    with start delay <%= @interval_delay %>
+<%- else %>
 #   with start delay 240    # optional: delay the first check by 4-minutes (by
 #                           # default Monit check immediately after Monit start)
+<%- end %>
 #
 #
 ## Set syslog logging with the 'daemon' facility. If the FACILITY option is


### PR DESCRIPTION
This adds the ability to set the delay for starting checking instances.
